### PR TITLE
Add Microcks contract testing + update to latest Dapr and Spring Boot on pizza-delivery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,3 @@
 go.work
 .DS_Store
 target/
-
-# IntelliJ IDEA
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 go.work
 .DS_Store
 target/
+
+# IntelliJ IDEA
+.idea/

--- a/.idea/pizza.iml
+++ b/.idea/pizza.iml
@@ -2,8 +2,30 @@
 <module type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
-    <content url="file://$MODULE_DIR$" />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.idea/sonarlint/issuestore/4/4" />
+      <excludeFolder url="file://$MODULE_DIR$/.idea/sonarlint/issuestore/4/e" />
+      <excludeFolder url="file://$MODULE_DIR$/.idea/sonarlint/issuestore/8/3" />
+      <excludeFolder url="file://$MODULE_DIR$/.idea/sonarlint/issuestore/8/8" />
+      <excludeFolder url="file://$MODULE_DIR$/.idea/sonarlint/issuestore/9" />
+      <excludeFolder url="file://$MODULE_DIR$/.idea/sonarlint/issuestore/c" />
+      <excludeFolder url="file://$MODULE_DIR$/.idea/sonarlint/issuestore/d/5" />
+      <excludeFolder url="file://$MODULE_DIR$/.idea/sonarlint/issuestore/e" />
+      <excludeFolder url="file://$MODULE_DIR$/.idea/sonarlint/issuestore/f" />
+      <excludeFolder url="file://$MODULE_DIR$/.idea/sonarlint/securityhotspotstore/4/4" />
+      <excludeFolder url="file://$MODULE_DIR$/.idea/sonarlint/securityhotspotstore/4/e" />
+      <excludeFolder url="file://$MODULE_DIR$/.idea/sonarlint/securityhotspotstore/8/3" />
+      <excludeFolder url="file://$MODULE_DIR$/.idea/sonarlint/securityhotspotstore/8/8" />
+      <excludeFolder url="file://$MODULE_DIR$/.idea/sonarlint/securityhotspotstore/9" />
+      <excludeFolder url="file://$MODULE_DIR$/.idea/sonarlint/securityhotspotstore/c" />
+      <excludeFolder url="file://$MODULE_DIR$/.idea/sonarlint/securityhotspotstore/d/5" />
+      <excludeFolder url="file://$MODULE_DIR$/.idea/sonarlint/securityhotspotstore/e" />
+      <excludeFolder url="file://$MODULE_DIR$/.idea/sonarlint/securityhotspotstore/f" />
+    </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="SonarLintModuleSettings">
+    <option name="uniqueId" value="87090316-c4c0-4efc-bb31-ab3903d6ba2a" />
   </component>
 </module>

--- a/pizza-delivery/pom.xml
+++ b/pizza-delivery/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.3</version>
+    <version>3.3.7</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>io.diagrid.dapr</groupId>
@@ -25,11 +25,19 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
+
         <dependency>
-            <groupId>io.diagrid.dapr</groupId>
+            <groupId>io.dapr.spring</groupId>
             <artifactId>dapr-spring-boot-starter</artifactId>
-            <version>0.10.7</version>
+            <version>0.13.3</version>
         </dependency>
+        <dependency>
+            <groupId>io.dapr.spring</groupId>
+            <artifactId>dapr-spring-boot-starter-test</artifactId>
+            <version>0.13.3</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
@@ -45,6 +53,23 @@
             <artifactId>hamcrest-all</artifactId>
             <version>1.3</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.github.microcks</groupId>
+            <artifactId>microcks-testcontainers</artifactId>
+            <version>0.3.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>kafka</artifactId>
+            <version>1.20.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.testcontainers</groupId>
+          <artifactId>junit-jupiter</artifactId>
+          <scope>test</scope>
         </dependency>
 	</dependencies>
     <build>

--- a/pizza-delivery/pom.xml
+++ b/pizza-delivery/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.3.7</version>
+		<version>3.3.7</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>io.diagrid.dapr</groupId>

--- a/pizza-delivery/src/main/java/io/diagrid/dapr/PizzaDelivery.java
+++ b/pizza-delivery/src/main/java/io/diagrid/dapr/PizzaDelivery.java
@@ -3,6 +3,7 @@ import java.util.Date;
 import java.util.List;
 import static java.util.Collections.singletonMap;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -15,7 +16,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import io.dapr.client.DaprClient;
-import io.dapr.client.DaprClientBuilder;
 import io.dapr.client.domain.Metadata;
 
 @SpringBootApplication
@@ -23,7 +23,9 @@ import io.dapr.client.domain.Metadata;
 public class PizzaDelivery {
 
   private static final String MESSAGE_TTL_IN_SECONDS = "1000";
-  
+
+  @Autowired
+  private DaprClient daprClient;
   @Value("${PUB_SUB_NAME:pubsub}")
   private String PUB_SUB_NAME;
   @Value("${PUB_SUB_TOPIC:topic}")
@@ -112,10 +114,10 @@ public class PizzaDelivery {
     pepperoni, margherita, hawaiian, vegetarian
   }
   
-  private void emitEvent(Event event) {
+  protected void emitEvent(Event event) {
     System.out.println("> Emitting Delivery Event: "+ event.toString());
-    try (DaprClient client = (new DaprClientBuilder()).build()) {
-      client.publishEvent(PUB_SUB_NAME,
+    try {
+       daprClient.publishEvent(PUB_SUB_NAME,
           PUB_SUB_TOPIC,
           event,
           singletonMap(Metadata.TTL_IN_SECONDS, MESSAGE_TTL_IN_SECONDS)).block();

--- a/pizza-delivery/src/test/java/io/diagrid/dapr/DaprTestContainersConfig.java
+++ b/pizza-delivery/src/test/java/io/diagrid/dapr/DaprTestContainersConfig.java
@@ -1,0 +1,67 @@
+package io.diagrid.dapr;
+
+import io.github.microcks.testcontainers.MicrocksContainersEnsemble;
+import io.github.microcks.testcontainers.connection.KafkaConnection;
+
+import io.dapr.testcontainers.Component;
+import io.dapr.testcontainers.DaprContainer;
+import io.dapr.testcontainers.Subscription;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Map;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class DaprTestContainersConfig {
+    private static Network network = Network.newNetwork();
+    private KafkaContainer kafkaContainer;
+    private DaprContainer daprContainer;
+
+    @Bean
+    @ServiceConnection
+    DaprContainer daprContainer(DynamicPropertyRegistry registry, KafkaContainer kafkaContainer) {
+        daprContainer = new DaprContainer("daprio/daprd")
+            .withAppName("local-dapr-app")
+            .withAppPort(8080)
+            .withNetwork(network)
+            .withComponent(new Component("pubsub", "pubsub.kafka", "v1",
+                  Map.of(
+                        "brokers", "kafka:19092",
+                        "authType", "none"
+                  )))
+            .withSubscription(new Subscription(
+                  "pizza-store-subscription",
+                  "pubsub", "topic", "/events"))
+            .withAppChannelAddress("host.testcontainers.internal")
+            .dependsOn(kafkaContainer);
+
+        org.testcontainers.Testcontainers.exposeHostPorts(8080);
+        return daprContainer;
+    }
+
+    @Bean
+    @ServiceConnection
+    KafkaContainer kafkaContainer() {
+        kafkaContainer = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"))
+            .withNetwork(network)
+            .withNetworkAliases("kafka")
+            .withListener(() -> "kafka:19092");
+        return kafkaContainer;
+    }
+
+    @Bean
+    MicrocksContainersEnsemble microcksEnsemble(DynamicPropertyRegistry registry) {
+        MicrocksContainersEnsemble ensemble = new MicrocksContainersEnsemble(network, "quay.io/microcks/microcks-uber:1.11.0-native")
+            .withAsyncFeature()
+            .withAccessToHost(true)
+            .withKafkaConnection(new KafkaConnection("kafka:19092"))
+            .withMainArtifacts("delivery-openapi.yaml", "delivery-asyncapi.yaml")
+            .withAsyncDependsOn(kafkaContainer);
+        return ensemble;
+    }
+}

--- a/pizza-delivery/src/test/java/io/diagrid/dapr/PizzaDeliveryAppTest.java
+++ b/pizza-delivery/src/test/java/io/diagrid/dapr/PizzaDeliveryAppTest.java
@@ -2,22 +2,13 @@ package io.diagrid.dapr;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.testcontainers.context.ImportTestcontainers;
-
-import io.diagrid.dapr.profiles.DaprBasicProfile;
 
 @SpringBootApplication
 public class PizzaDeliveryAppTest {
+
     public static void main(String[] args) {
         SpringApplication.from(PizzaDelivery::main)
-                .with(DaprTestConfiguration.class)
+                .with(DaprTestContainersConfig.class)
                 .run(args);
     }
-
-    
-    @ImportTestcontainers(DaprBasicProfile.class)
-    static class DaprTestConfiguration {
-       
-    }
-
 }

--- a/pizza-delivery/src/test/java/io/diagrid/dapr/PizzaDeliveryContractTest.java
+++ b/pizza-delivery/src/test/java/io/diagrid/dapr/PizzaDeliveryContractTest.java
@@ -1,0 +1,193 @@
+package io.diagrid.dapr;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dapr.client.domain.CloudEvent;
+import io.diagrid.dapr.PizzaDelivery.Event;
+import io.diagrid.dapr.PizzaDelivery.EventType;
+import io.diagrid.dapr.PizzaDelivery.Order;
+import io.diagrid.dapr.PizzaDelivery.OrderItem;
+
+import io.github.microcks.testcontainers.MicrocksContainersEnsemble;
+import io.github.microcks.testcontainers.model.EventMessage;
+import io.github.microcks.testcontainers.model.TestRequest;
+import io.github.microcks.testcontainers.model.TestResult;
+import io.github.microcks.testcontainers.model.TestRunnerType;
+import io.github.microcks.testcontainers.model.UnidirectionalEvent;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import java.time.Duration;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(classes=PizzaDeliveryAppTest.class, webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@Import(DaprTestContainersConfig.class)
+class PizzaDeliveryContractTest {
+
+    @Autowired
+    MicrocksContainersEnsemble microcksEnsemble;
+
+    @Autowired
+    PizzaDelivery service;
+
+    @Test
+    void testEventIsPublishedOnKafkaAndIsConformantToSpec() {
+        // Prepare a Microcks test.
+        TestRequest kafkaTest = new TestRequest.Builder()
+            .serviceId("Pizza Delivery Events:1.0.0")
+            .filteredOperations(List.of("RECEIVE receiveDeliveryEvents"))
+            .runnerType(TestRunnerType.ASYNC_API_SCHEMA.name())
+            .testEndpoint("kafka://kafka:19092/topic")
+            .timeout(Duration.ofSeconds(3))
+            .build();
+
+        // Prepare an application Event.
+        Event event = new Event(EventType.ORDER_ON_ITS_WAY,
+            new Order("123-456-789",
+                  List.of(new OrderItem(PizzaDelivery.PizzaType.pepperoni, 1)),
+                  new Date()),
+            "delivery",
+            "The order is on its way to your address.");
+
+        try {
+            // Launch the Microcks test and wait a bit to be sure it actually connects to Kafka.
+            CompletableFuture<TestResult> testResultFuture = microcksEnsemble.getMicrocksContainer().testEndpointAsync(kafkaTest);
+            TimeUnit.MILLISECONDS.sleep(750L);
+
+            // Invoke the application to emit an order event.
+            service.emitEvent(event);
+
+            // Get the Microcks test result.
+            TestResult testResult = testResultFuture.get();
+
+            //System.err.println(microcksEnsemble.getAsyncMinionContainer().getLogs());
+            //ObjectMapper mapper = new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
+            //System.out.println("testResult: " + mapper.writeValueAsString(testResult));
+
+            // Check success and that we read 1 valid message on the topic.
+            assertTrue(testResult.isSuccess());
+            assertFalse(testResult.getTestCaseResults().isEmpty());
+            assertEquals(1, testResult.getTestCaseResults().get(0).getTestStepResults().size());
+
+            // Check the content of the emitted event, read from Kafka topic.
+            List<UnidirectionalEvent> events = microcksEnsemble.getMicrocksContainer()
+                  .getEventMessagesForTestCase(testResult, "RECEIVE receiveDeliveryEvents");
+
+            assertEquals(1, events.size());
+
+            EventMessage message = events.get(0).getEventMessage();
+            Map<String, Object> messageMap = new ObjectMapper().readValue(message.getContent(), new TypeReference<>() {});
+
+            // Properties from the cloud event message should match the application config and the event.
+            assertEquals("1.0", messageMap.get("specversion"));
+            assertEquals("local-dapr-app", messageMap.get("source"));
+            assertEquals("com.dapr.event.sent", messageMap.get("type"));
+
+            Map<String, Object> eventMap = (Map<String, Object>) messageMap.get("data");
+            assertEquals("delivery", eventMap.get("service"));
+            assertEquals("The order is on its way to your address.", eventMap.get("message"));
+
+            // You can also try to deserialize the message content to a CloudEvent object.
+            // We have to ignore the failure on unknown expiration time property.
+            CloudEvent<Event> cloudEvent = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                  .readValue(message.getContent(), new TypeReference<CloudEvent<Event>>() {});
+            assertEquals("1.0", cloudEvent.getSpecversion());
+            assertEquals("local-dapr-app", cloudEvent.getSource());
+            assertEquals("com.dapr.event.sent", cloudEvent.getType());
+            assertEquals("delivery", cloudEvent.getData().service());
+            assertEquals("The order is on its way to your address.", cloudEvent.getData().message());
+
+        } catch (Exception e) {
+            fail("No exception should be thrown when testing Kafka publication", e);
+        }
+    }
+
+    @Test
+    void testDeliverEndpointIsConformantToSpec() throws Exception {
+         // Prepare a Microcks test.
+         TestRequest openAPITest = new TestRequest.Builder()
+               .serviceId("Pizza Delivery API:1.0.0")
+               .runnerType(TestRunnerType.OPEN_API_SCHEMA.name())
+               .testEndpoint("http://host.testcontainers.internal:8080")
+               .timeout(Duration.ofSeconds(2))
+               .build();
+
+         TestResult testResult = microcksEnsemble.getMicrocksContainer().testEndpoint(openAPITest);
+
+         // You may inspect complete response object with following:
+         //ObjectMapper mapper = new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
+         //System.out.println(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(testResult));
+
+         assertTrue(testResult.isSuccess());
+         // We tested 1 operation (PUT /deliver).
+         assertEquals(1, testResult.getTestCaseResults().size());
+         // We tested with 2 samples (salaboy and lbroudoux).
+         assertEquals(2, testResult.getTestCaseResults().get(0).getTestStepResults().size());
+    }
+
+    @Test
+    void testCompleteFlowAndBusinessLogicIsConformantToSpecs() throws Exception {
+        // Prepare a Microcks test for event production.
+        TestRequest kafkaTest = new TestRequest.Builder()
+               .serviceId("Pizza Delivery Events:1.0.0")
+               .filteredOperations(List.of("RECEIVE receiveDeliveryEvents"))
+               .runnerType(TestRunnerType.ASYNC_API_SCHEMA.name())
+               .testEndpoint("kafka://kafka:19092/topic")
+               .timeout(Duration.ofSeconds(14))
+               .build();
+
+        // Prepare a Microcks test for event trigerring endpoint.
+        TestRequest openAPITest = new TestRequest.Builder()
+               .serviceId("Pizza Delivery API:1.0.0")
+               .runnerType(TestRunnerType.OPEN_API_SCHEMA.name())
+               .testEndpoint("http://host.testcontainers.internal:8080")
+               .timeout(Duration.ofSeconds(2))
+               .build();
+
+        try {
+            // Launch the Microcks test and wait a bit to be sure it actually connects to Kafka.
+            CompletableFuture<TestResult> testResultFuture = microcksEnsemble.getMicrocksContainer().testEndpointAsync(kafkaTest);
+            TimeUnit.MILLISECONDS.sleep(750L);
+
+            // Invoke the application to emit an order event.
+            TestResult openAPIResult = microcksEnsemble.getMicrocksContainer().testEndpoint(openAPITest);
+
+            // You may inspect complete response object with following:
+            //ObjectMapper mapper = new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
+            //System.out.println(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(openAPIResult));
+
+            // Check this first interaction is ok.
+            assertTrue(openAPIResult.isSuccess());
+
+            // Get the Microcks test result.
+            TestResult kafkaResult = testResultFuture.get();
+
+            // You may inspect complete response object with following:
+            //System.out.println(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(kafkaResult));
+
+            // Check success and that we read 8 valid message on the topic.
+            // 8 because 2 orders are placed (per the OpenAPI samples) and 4 messages are sent for each order.
+            assertTrue(kafkaResult.isSuccess());
+            assertFalse(kafkaResult.getTestCaseResults().isEmpty());
+            assertEquals(8, kafkaResult.getTestCaseResults().get(0).getTestStepResults().size());
+
+            // Check the content of the emitted event, read from Kafka topic.
+            List<UnidirectionalEvent> events = microcksEnsemble.getMicrocksContainer()
+                  .getEventMessagesForTestCase(kafkaResult, "RECEIVE receiveDeliveryEvents");
+
+            assertEquals(8, events.size());
+        } catch (Exception e) {
+            fail("No exception should be thrown when testing Kafka publication", e);
+        }
+    }
+}

--- a/pizza-delivery/src/test/java/io/diagrid/dapr/PizzaDeliveryTest.java
+++ b/pizza-delivery/src/test/java/io/diagrid/dapr/PizzaDeliveryTest.java
@@ -3,6 +3,7 @@ package io.diagrid.dapr;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import static org.junit.Assert.*;
 
@@ -22,14 +23,14 @@ import io.restassured.http.ContentType;
 import static io.restassured.RestAssured.*;
 
 @SpringBootTest(classes=PizzaDeliveryAppTest.class, webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
-@Testcontainers
-public class PizzaDeliveryTest {
+@Import(DaprTestContainersConfig.class)
+class PizzaDeliveryTest {
 
     @Autowired
     private SubscriptionsRestController subscriptionsRestController;
 
     @Test
-    public void testDelivery() throws Exception {
+    void testDelivery() throws Exception {
         with().body(new Order(UUID.randomUUID().toString(), 
                                 Arrays.asList(new OrderItem(PizzaType.pepperoni, 1)), 
                                 new Date()))
@@ -48,7 +49,7 @@ public class PizzaDeliveryTest {
         assertEquals("The content of the cloud event should be the order-out-on-its-way event", EventType.ORDER_ON_ITS_WAY, events.get(2).getData().type());
         assertEquals("The content of the cloud event should be the order-completed event", EventType.ORDER_COMPLETED, events.get(3).getData().type());
 
-      
+
     }
 
 }

--- a/pizza-delivery/src/test/resources/delivery-asyncapi.yaml
+++ b/pizza-delivery/src/test/resources/delivery-asyncapi.yaml
@@ -1,0 +1,123 @@
+asyncapi: 3.0.0
+info:
+  title: Pizza Delivery Events
+  version: 1.0.0
+  description: This API allows to track the delivery status of pizza orders.
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+defaultContentType: application/json
+channels:
+  deliveryEvents:
+    address: events
+    messages:
+      deliveryEvent:
+        $ref: '#/components/messages/event'
+operations:
+  receiveDeliveryEvents:
+    action: receive
+    channel:
+      $ref: '#/channels/deliveryEvents'
+    messages:
+      - $ref: '#/channels/deliveryEvents/messages/deliveryEvent'
+components:
+  messages:
+    event:
+      payload:
+        $ref: '#/components/schemas/ReceivedEvent'
+        examples:
+          - name: On its way
+            payload:
+              specversion: '1.0'
+              type: com.dapr.event.sent
+              source: local-dapr-app
+              id: 952d739f-5556-4772-8187-c39e18139a88
+              time: '2025-01-29T09:27:15Z'
+              datacontenttype: application/json
+              data:
+                type: order-on-its-way
+                order:
+                  customer:
+                    name: lbroudoux
+                    email: laurent.broudoux@gmail.com
+                  id: 123-456-789
+                  items:
+                    - type: vegetarian
+                      amount: 1
+                  orderDate: 1738142460556
+                message: The order is on its way to your address.
+          - name: Completed
+            payload:
+              specversion: '1.0'
+              type: com.dapr.event.sent
+              source: local-dapr-app
+              id: 952d739f-5556-4772-8187-c39e18139a89
+              time: '2025-01-29T09:29:25Z'
+              data:
+                type: order-completed
+                order:
+                  customer:
+                    name: lbroudoux
+                    email: laurent.broudoux@gmail.com
+                  id: 123-456-789
+                  items:
+                    - type: vegetarian
+                      amount: 1
+                  orderDate: 1738142460556
+                message: Your order has been delivered.
+  schemas:
+    Order:
+      type: object
+      properties:
+        id:
+          type: string
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrderItem'
+        orderDate:
+          type: number
+      required:
+        - id
+        - items
+        - orderDate
+      additionalProperties: true
+    OrderItem:
+      type: object
+      properties:
+        type:
+          type: string
+        amount:
+          type: integer
+      required:
+        - type
+        - amount
+    Event:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - order-on-its-way
+            - order-completed
+        order:
+          $ref: '#/components/schemas/Order'
+        service:
+          type: string
+          enum:
+            - delivery
+        message:
+          type: string
+      required:
+        - type
+        - order
+        - service
+        - message
+    ReceivedEvent:
+      type: object
+      allOf:
+        - $ref: 'https://raw.githubusercontent.com/cloudevents/spec/v1.0.1/spec.json'
+      properties:
+        data:
+          $ref: '#/components/schemas/Event'
+

--- a/pizza-delivery/src/test/resources/delivery-openapi.yaml
+++ b/pizza-delivery/src/test/resources/delivery-openapi.yaml
@@ -1,0 +1,79 @@
+openapi: 3.0.2
+info:
+  title: Pizza Delivery API
+  version: 1.0.0
+  description: This API allows to start the delivery of pizzas
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+paths:
+  /deliver:
+    put:
+      operationId: startDelivery
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Order'
+            examples:
+              salaboy:
+                value: |-
+                  {
+                    "id": "abc-def-ghi",
+                    "customer": {
+                      "name": "salaboy",
+                      "email": "salaboy@mail.com"
+                    },
+                    "items": [
+                      {
+                      "type":"pepperoni",
+                      "amount": 1
+                      }
+                    ],
+                    "orderDate": 1738142460555
+                  }
+              lbroudoux:
+                value:
+                  id: 123-456-789
+                  customer:
+                    name: lbroudoux
+                    email: laurent.broudoux@gmail.com
+                  items:
+                    - type: vegetarian
+                      amount: 1
+                  orderDate: 1738142460556
+      responses:
+        '200':
+          description: Delivery started
+          x-microcks-refs:
+            - salaboy
+            - lbroudoux
+components:
+  schemas:
+    Order:
+      type: object
+      properties:
+        id:
+          type: string
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrderItem'
+        orderDate:
+          type: number
+      required:
+        - id
+        - items
+        - orderDate
+      additionalProperties: true
+    OrderItem:
+      type: object
+      properties:
+        type:
+          type: string
+        amount:
+          type: integer
+      required:
+        - type
+        - amount


### PR DESCRIPTION
This PR is only for `pizza-delivery` module. Other PRs to come soon for other modules if happy with this one.

# Changes

- Bump to Spring Boot 3.3.7
- Bump to Dapr spring-boot-starter 0.13.4
- Add KafkaContainer bound to Dapr sidecar
- Add Microcks support for contract-testing

## New Microcks contract tests

1. `PizzaDeliveryContractTest.testEventIsPublishedOnKafkaAndIsConformantToSpec()`

Ensure that emitting an event using DaprClient actually produces a valid message on the correct Kafka topic
* Microcks test read messages on Kafka topic
* Microcks validate them against the schema information (cloud event + data payload) found in the new `delivery-asyncapi.yaml` spec
* Microcks give access to read messages to check the actual content

2. `PizzaDeliveryContractTest.testDeliverEndpointIsConformantToSpec()`

Ensure that the exposed API `PUT /deliver` conforms to the new `delivery-openapi.yaml` spec.
Handy to ensure we didn't break the backward compatibility when applying changes / adding new features.

3. `PizzaDeliveryContractTest.testCompleteFlowAndBusinessLogicIsConformantToSpecs()`

Validate the complete flow and both contracts (OpenAPI and AsyncAPI) using Microcks only. 
- Microcks invokes the `PUT /deliver` endpoint on one side and checks conformance
- During that time, it also listens to Kafka topic to check related messages are actually sent and that they're valid.