### PR TITLE
Add Microcks contract testing + update to latest Dapr and Spring Boot on pizza-kitchen

### DIFF
--- a/pizza-kitchen/pom.xml
+++ b/pizza-kitchen/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.3</version>
+		<version>3.3.7</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>io.diagrid.dapr</groupId>
@@ -25,11 +25,19 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
+
         <dependency>
-            <groupId>io.diagrid.dapr</groupId>
-            <artifactId>dapr-spring-boot-starter</artifactId>
-            <version>0.10.7</version>
+          <groupId>io.dapr.spring</groupId>
+          <artifactId>dapr-spring-boot-starter</artifactId>
+          <version>0.13.3</version>
         </dependency>
+        <dependency>
+          <groupId>io.dapr.spring</groupId>
+          <artifactId>dapr-spring-boot-starter-test</artifactId>
+          <version>0.13.3</version>
+          <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
@@ -44,6 +52,23 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
             <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.github.microcks</groupId>
+            <artifactId>microcks-testcontainers</artifactId>
+            <version>0.3.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>kafka</artifactId>
+            <version>1.20.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 	</dependencies>

--- a/pizza-kitchen/pom.xml
+++ b/pizza-kitchen/pom.xml
@@ -16,6 +16,18 @@
 	<properties>
 		<java.version>17</java.version>
 	</properties>
+  <repositories>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+    </repository>
+  </repositories>
 	<dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -29,12 +41,12 @@
         <dependency>
           <groupId>io.dapr.spring</groupId>
           <artifactId>dapr-spring-boot-starter</artifactId>
-          <version>0.13.3</version>
+          <version>0.14.0-SNAPSHOT</version>
         </dependency>
         <dependency>
           <groupId>io.dapr.spring</groupId>
           <artifactId>dapr-spring-boot-starter-test</artifactId>
-          <version>0.13.3</version>
+          <version>0.14.0-SNAPSHOT</version>
           <scope>test</scope>
         </dependency>
 

--- a/pizza-kitchen/src/test/java/io/diagrid/dapr/DaprTestContainersConfig.java
+++ b/pizza-kitchen/src/test/java/io/diagrid/dapr/DaprTestContainersConfig.java
@@ -1,0 +1,66 @@
+package io.diagrid.dapr;
+
+import io.dapr.testcontainers.Component;
+import io.dapr.testcontainers.DaprContainer;
+import io.dapr.testcontainers.Subscription;
+import io.github.microcks.testcontainers.MicrocksContainersEnsemble;
+import io.github.microcks.testcontainers.connection.KafkaConnection;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Map;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class DaprTestContainersConfig {
+    private static Network network = Network.newNetwork();
+    private KafkaContainer kafkaContainer;
+    private DaprContainer daprContainer;
+
+    @Bean
+    @ServiceConnection
+    DaprContainer daprContainer(DynamicPropertyRegistry registry, KafkaContainer kafkaContainer) {
+        daprContainer = new DaprContainer("daprio/daprd")
+            .withAppName("local-dapr-app")
+            .withAppPort(8080)
+            .withNetwork(network)
+            .withComponent(new Component("pubsub", "pubsub.kafka", "v1",
+                  Map.of(
+                        "brokers", "kafka:19092",
+                        "authType", "none"
+                  )))
+            .withSubscription(new Subscription(
+                  "pizza-store-subscription",
+                  "pubsub", "topic", "/events"))
+            .withAppChannelAddress("host.testcontainers.internal")
+            .dependsOn(kafkaContainer);
+
+        org.testcontainers.Testcontainers.exposeHostPorts(8080);
+        return daprContainer;
+    }
+
+    @Bean
+    @ServiceConnection
+    KafkaContainer kafkaContainer() {
+        kafkaContainer = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"))
+            .withNetwork(network)
+            .withNetworkAliases("kafka")
+            .withListener(() -> "kafka:19092");
+        return kafkaContainer;
+    }
+
+    @Bean
+    MicrocksContainersEnsemble microcksEnsemble(DynamicPropertyRegistry registry) {
+        MicrocksContainersEnsemble ensemble = new MicrocksContainersEnsemble(network, "quay.io/microcks/microcks-uber:1.11.0-native")
+            .withAsyncFeature()
+            .withAccessToHost(true)
+            .withKafkaConnection(new KafkaConnection("kafka:19092"))
+            .withMainArtifacts("kitchen-openapi.yaml", "kitchen-asyncapi.yaml")
+            .withAsyncDependsOn(kafkaContainer);
+        return ensemble;
+    }
+}

--- a/pizza-kitchen/src/test/java/io/diagrid/dapr/PizzaKitchenAppTest.java
+++ b/pizza-kitchen/src/test/java/io/diagrid/dapr/PizzaKitchenAppTest.java
@@ -2,22 +2,13 @@ package io.diagrid.dapr;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.testcontainers.context.ImportTestcontainers;
-
-import io.diagrid.dapr.profiles.DaprBasicProfile;
 
 @SpringBootApplication
 public class PizzaKitchenAppTest {
+
     public static void main(String[] args) {
         SpringApplication.from(PizzaKitchen::main)
-                .with(DaprTestConfiguration.class)
+                .with(DaprTestContainersConfig.class)
                 .run(args);
     }
-
-    
-    @ImportTestcontainers(DaprBasicProfile.class)
-    static class DaprTestConfiguration {
-       
-    }
-
 }

--- a/pizza-kitchen/src/test/java/io/diagrid/dapr/PizzaKitchenContractTest.java
+++ b/pizza-kitchen/src/test/java/io/diagrid/dapr/PizzaKitchenContractTest.java
@@ -1,0 +1,195 @@
+package io.diagrid.dapr;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dapr.client.domain.CloudEvent;
+import io.diagrid.dapr.PizzaKitchen.Event;
+import io.diagrid.dapr.PizzaKitchen.EventType;
+import io.diagrid.dapr.PizzaKitchen.Order;
+import io.diagrid.dapr.PizzaKitchen.OrderItem;
+import io.github.microcks.testcontainers.MicrocksContainersEnsemble;
+import io.github.microcks.testcontainers.model.EventMessage;
+import io.github.microcks.testcontainers.model.TestRequest;
+import io.github.microcks.testcontainers.model.TestResult;
+import io.github.microcks.testcontainers.model.TestRunnerType;
+import io.github.microcks.testcontainers.model.UnidirectionalEvent;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import java.time.Duration;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(classes=PizzaKitchenAppTest.class, webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@Import(DaprTestContainersConfig.class)
+class PizzaKitchenContractTest {
+
+    @Autowired
+    MicrocksContainersEnsemble microcksEnsemble;
+
+    @Autowired
+    PizzaKitchen service;
+
+    @Test
+    void testEventIsPublishedOnKafkaAndIsConformantToSpec() {
+        // Prepare a Microcks test.
+        TestRequest kafkaTest = new TestRequest.Builder()
+            .serviceId("Pizza Kitchen Events:1.0.0")
+            .filteredOperations(List.of("RECEIVE receivePreparationEvents"))
+            .runnerType(TestRunnerType.ASYNC_API_SCHEMA.name())
+            .testEndpoint("kafka://kafka:19092/topic")
+            .timeout(Duration.ofSeconds(3))
+            .build();
+
+        // Prepare an application Event.
+        Event event = new Event(EventType.ORDER_IN_PREPARATION,
+             new Order("123-456-789",
+                  List.of(new OrderItem(PizzaKitchen.PizzaType.pepperoni, 1)),
+                  new Date()),
+             "kitchen",
+             "The order is now in the kitchen.");
+
+        try {
+            // Launch the Microcks test and wait a bit to be sure it actually connects to Kafka.
+            CompletableFuture<TestResult> testResultFuture = microcksEnsemble.getMicrocksContainer().testEndpointAsync(kafkaTest);
+            TimeUnit.MILLISECONDS.sleep(750L);
+
+            // Invoke the application to emit an order event.
+            service.emitEvent(event);
+
+            // Get the Microcks test result.
+            TestResult testResult = testResultFuture.get();
+
+            //System.err.println(microcksEnsemble.getAsyncMinionContainer().getLogs());
+            //ObjectMapper mapper = new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
+            //System.out.println("testResult: " + mapper.writeValueAsString(testResult));
+
+            // Check success and that we read 1 valid message on the topic.
+            assertTrue(testResult.isSuccess());
+            assertFalse(testResult.getTestCaseResults().isEmpty());
+            assertEquals(1, testResult.getTestCaseResults().get(0).getTestStepResults().size());
+
+            // Check the content of the emitted event, read from Kafka topic.
+            List<UnidirectionalEvent> events = microcksEnsemble.getMicrocksContainer()
+                  .getEventMessagesForTestCase(testResult, "RECEIVE receivePreparationEvents");
+
+            assertEquals(1, events.size());
+
+            EventMessage message = events.get(0).getEventMessage();
+            Map<String, Object> messageMap = new ObjectMapper().readValue(message.getContent(), new TypeReference<>() {});
+
+            // Properties from the cloud event message should match the application config and the event.
+            assertEquals("1.0", messageMap.get("specversion"));
+            assertEquals("local-dapr-app", messageMap.get("source"));
+            assertEquals("com.dapr.event.sent", messageMap.get("type"));
+
+            Map<String, Object> eventMap = (Map<String, Object>) messageMap.get("data");
+            assertEquals("kitchen", eventMap.get("service"));
+            assertEquals("The order is now in the kitchen.", eventMap.get("message"));
+
+            // You can also try to deserialize the message content to a CloudEvent object.
+            // We have to ignore the failure on unknown expiration time property.
+            CloudEvent<Event> cloudEvent = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                  .readValue(message.getContent(), new TypeReference<CloudEvent<Event>>() {});
+            assertEquals("1.0", cloudEvent.getSpecversion());
+            assertEquals("local-dapr-app", cloudEvent.getSource());
+            assertEquals("com.dapr.event.sent", cloudEvent.getType());
+            assertEquals("kitchen", cloudEvent.getData().service());
+            assertEquals("The order is now in the kitchen.", cloudEvent.getData().message());
+        } catch (Exception e) {
+            fail("No exception should be thrown when testing Kafka publication", e);
+        }
+    }
+
+    @Test
+    void testDeliverEndpointIsConformantToSpec() throws Exception {
+        // Prepare a Microcks test.
+        TestRequest openAPITest = new TestRequest.Builder()
+              .serviceId("Pizza Kitchen API:1.0.0")
+              .runnerType(TestRunnerType.OPEN_API_SCHEMA.name())
+              .testEndpoint("http://host.testcontainers.internal:8080")
+              .timeout(Duration.ofSeconds(2))
+              .build();
+
+        TestResult testResult = microcksEnsemble.getMicrocksContainer().testEndpoint(openAPITest);
+
+        // You may inspect complete response object with following:
+        //ObjectMapper mapper = new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        //System.out.println(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(testResult));
+
+        assertTrue(testResult.isSuccess());
+        // We tested 1 operation (PUT /prepare).
+        assertEquals(1, testResult.getTestCaseResults().size());
+        // We tested with 2 samples (salaboy and lbroudoux).
+        assertEquals(2, testResult.getTestCaseResults().get(0).getTestStepResults().size());
+
+        // We should wait here to avoid in-flight messages to be seen by other tests.
+        // 20 seconcs because of PizzaKitchen implemenetation (5000 + 15000).
+        TimeUnit.SECONDS.sleep(20L);
+    }
+
+    @Test
+    void testCompleteFlowAndBusinessLogicIsConformantToSpecs() throws Exception {
+        // Prepare a Microcks test for event production.
+        TestRequest kafkaTest = new TestRequest.Builder()
+              .serviceId("Pizza Kitchen Events:1.0.0")
+              .filteredOperations(List.of("RECEIVE receivePreparationEvents"))
+              .runnerType(TestRunnerType.ASYNC_API_SCHEMA.name())
+              .testEndpoint("kafka://kafka:19092/topic")
+              .timeout(Duration.ofSeconds(22))
+              .build();
+
+        // Prepare a Microcks test for event trigerring endpoint.
+        TestRequest openAPITest = new TestRequest.Builder()
+               .serviceId("Pizza Kitchen API:1.0.0")
+               .runnerType(TestRunnerType.OPEN_API_SCHEMA.name())
+               .testEndpoint("http://host.testcontainers.internal:8080")
+               .timeout(Duration.ofSeconds(2))
+               .build();
+
+        try {
+            // Launch the Microcks test and wait a bit to be sure it actually connects to Kafka.
+            CompletableFuture<TestResult> testResultFuture = microcksEnsemble.getMicrocksContainer().testEndpointAsync(kafkaTest);
+            TimeUnit.MILLISECONDS.sleep(750L);
+
+            // Invoke the application to emit an order event.
+            TestResult openAPIResult = microcksEnsemble.getMicrocksContainer().testEndpoint(openAPITest);
+
+            // You may inspect complete response object with following:
+            //ObjectMapper mapper = new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
+            //System.out.println(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(openAPIResult));
+
+            // Check this first interaction is ok.
+            assertTrue(openAPIResult.isSuccess());
+
+            // Get the Microcks test result.
+            TestResult kafkaResult = testResultFuture.get();
+
+            // You may inspect complete response object with following:
+            //System.out.println(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(kafkaResult));
+
+            // Check success and that we read 8 valid message on the topic.
+            // 4 because 2 orders are placed (per the OpenAPI samples) and 2 messages are sent for each order.
+            assertTrue(kafkaResult.isSuccess());
+            assertFalse(kafkaResult.getTestCaseResults().isEmpty());
+            assertEquals(4, kafkaResult.getTestCaseResults().get(0).getTestStepResults().size());
+
+            // Check the content of the emitted event, read from Kafka topic.
+            List<UnidirectionalEvent> events = microcksEnsemble.getMicrocksContainer()
+                  .getEventMessagesForTestCase(kafkaResult, "RECEIVE receivePreparationEvents");
+
+            assertEquals(4, events.size());
+        } catch (Exception e) {
+            fail("No exception should be thrown when testing Kafka publication", e);
+        }
+    }
+}

--- a/pizza-kitchen/src/test/java/io/diagrid/dapr/PizzaKitchenTest.java
+++ b/pizza-kitchen/src/test/java/io/diagrid/dapr/PizzaKitchenTest.java
@@ -3,7 +3,7 @@ package io.diagrid.dapr;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.testcontainers.junit.jupiter.Testcontainers;
+import org.springframework.context.annotation.Import;
 import static org.junit.Assert.*;
 
 import java.util.Arrays;
@@ -22,15 +22,19 @@ import io.restassured.http.ContentType;
 import static io.restassured.RestAssured.*;
 
 @SpringBootTest(classes=PizzaKitchenAppTest.class, webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
-@Testcontainers
-public class PizzaKitchenTest {
+@Import(DaprTestContainersConfig.class)
+class PizzaKitchenTest {
 
     @Autowired
     private SubscriptionsRestController subscriptionsRestController;
 
     
     @Test
-    public void testPrepareOrderRequest() throws Exception {
+    void testPrepareOrderRequest() throws Exception {
+        // Get initial events size - it may not be empty if we're running in a test suite.
+        List<CloudEvent<Event>> events = subscriptionsRestController.getAllEvents();
+        int eventsSize = events.size();
+
         with().body(new Order(UUID.randomUUID().toString(), 
                                 Arrays.asList(new OrderItem(PizzaType.pepperoni, 1)), 
                                 new Date()))
@@ -40,12 +44,12 @@ public class PizzaKitchenTest {
         .then().assertThat().statusCode(200);
 
         // Wait for the event to arrive
-        Thread.sleep(17000);
+        Thread.sleep(20000);
 
-        List<CloudEvent<Event>> events = subscriptionsRestController.getAllEvents();
-        assertEquals("Two published event are expected",2, events.size());
-        assertEquals("The content of the cloud event should be the in preparation event", EventType.ORDER_IN_PREPARATION, events.get(0).getData().type());
-        assertEquals("The content of the cloud event should be the ready event", EventType.ORDER_READY, events.get(1).getData().type());
+        events = subscriptionsRestController.getAllEvents();
+        assertEquals("Two published event are expected",2, events.size() - eventsSize);
+        assertEquals("The content of the cloud event should be the in preparation event", EventType.ORDER_IN_PREPARATION, events.get(eventsSize).getData().type());
+        assertEquals("The content of the cloud event should be the ready event", EventType.ORDER_READY, events.get(eventsSize + 1).getData().type());
 
     }
 

--- a/pizza-kitchen/src/test/resources/kitchen-asyncapi.yaml
+++ b/pizza-kitchen/src/test/resources/kitchen-asyncapi.yaml
@@ -1,0 +1,122 @@
+asyncapi: 3.0.0
+info:
+  title: Pizza Kitchen Events
+  version: 1.0.0
+  description: This API allows to track the preparation process of pizza orders.
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+defaultContentType: application/json
+channels:
+  preparationEvents:
+    address: events
+    messages:
+      preparationEvent:
+        $ref: '#/components/messages/event'
+operations:
+  receivePreparationEvents:
+    action: receive
+    channel:
+      $ref: '#/channels/preparationEvents'
+    messages:
+      - $ref: '#/channels/preparationEvents/messages/preparationEvent'
+components:
+  messages:
+    event:
+      payload:
+        $ref: '#/components/schemas/ReceivedEvent'
+        examples:
+          - name: In preparation
+            payload:
+              specversion: '1.0'
+              type: com.dapr.event.sent
+              source: local-dapr-app
+              id: 952d739f-5556-4772-8187-c39e18139a86
+              time: '2025-01-29T09:27:15Z'
+              datacontenttype: application/json
+              data:
+                type: order-in-preparation
+                order:
+                  customer:
+                    name: lbroudoux
+                    email: laurent.broudoux@gmail.com
+                  id: 123-456-789
+                  items:
+                    - type: vegetarian
+                      amount: 1
+                  orderDate: 1738142460556
+                message: The order is now in the kitchen.
+          - name: Ready
+            payload:
+              specversion: '1.0'
+              type: com.dapr.event.sent
+              source: local-dapr-app
+              id: 952d739f-5556-4772-8187-c39e18139a87
+              time: '2025-01-29T09:29:25Z'
+              data:
+                type: order-ready
+                order:
+                  customer:
+                    name: lbroudoux
+                    email: laurent.broudoux@gmail.com
+                  id: 123-456-789
+                  items:
+                    - type: vegetarian
+                      amount: 1
+                  orderDate: 1738142460556
+                message: Your pizza is ready and waiting to be delivered.
+  schemas:
+    Order:
+      type: object
+      properties:
+        id:
+          type: string
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrderItem'
+        orderDate:
+          type: number
+      required:
+        - id
+        - items
+        - orderDate
+      additionalProperties: true
+    OrderItem:
+      type: object
+      properties:
+        type:
+          type: string
+        amount:
+          type: integer
+      required:
+        - type
+        - amount
+    Event:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - order-in-preparation
+            - order-ready
+        order:
+          $ref: '#/components/schemas/Order'
+        service:
+          type: string
+          enum:
+            - kitchen
+        message:
+          type: string
+      required:
+        - type
+        - order
+        - service
+        - message
+    ReceivedEvent:
+      type: object
+      allOf:
+        - $ref: 'https://raw.githubusercontent.com/cloudevents/spec/v1.0.1/spec.json'
+      properties:
+        data:
+          $ref: '#/components/schemas/Event'

--- a/pizza-kitchen/src/test/resources/kitchen-openapi.yaml
+++ b/pizza-kitchen/src/test/resources/kitchen-openapi.yaml
@@ -1,0 +1,79 @@
+openapi: 3.0.2
+info:
+  title: Pizza Kitchen API
+  version: 1.0.0
+  description: This API allows to start the preparation of pizzas
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+paths:
+  /prepare:
+    put:
+      operationId: startPreparation
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Order'
+            examples:
+              salaboy:
+                value: |-
+                  {
+                    "id": "abc-def-ghi",
+                    "customer": {
+                      "name": "salaboy",
+                      "email": "salaboy@mail.com"
+                    },
+                    "items": [
+                      {
+                      "type":"pepperoni",
+                      "amount": 1
+                      }
+                    ],
+                    "orderDate": 1738142460555
+                  }
+              lbroudoux:
+                value:
+                  id: 123-456-789
+                  customer:
+                    name: lbroudoux
+                    email: laurent.broudoux@gmail.com
+                  items:
+                    - type: vegetarian
+                      amount: 1
+                  orderDate: 1738142460556
+      responses:
+        '200':
+          description: Preparation started
+          x-microcks-refs:
+            - salaboy
+            - lbroudoux
+components:
+  schemas:
+    Order:
+      type: object
+      properties:
+        id:
+          type: string
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrderItem'
+        orderDate:
+          type: number
+      required:
+        - id
+        - items
+        - orderDate
+      additionalProperties: true
+    OrderItem:
+      type: object
+      properties:
+        type:
+          type: string
+        amount:
+          type: integer
+      required:
+        - type
+        - amount


### PR DESCRIPTION
This PR is only for `pizza-kitchen` module. It's similar to #11 

# Changes

- Bump to Spring Boot 3.3.7
- Bump to Dapr spring-boot-starter 0.13.4
- Add KafkaContainer bound to Dapr sidecar
- Add Microcks support for contract-testing

## New Microcks contract tests

1. `PizzaKitchenContractTest.testEventIsPublishedOnKafkaAndIsConformantToSpec()`

Ensure that emitting an event using DaprClient actually produces a valid message on the correct Kafka topic
* Microcks test read messages on Kafka topic
* Microcks validate them against the schema information (cloud event + data payload) found in the new `kitchen-asyncapi.yaml` spec
* Microcks give access to read messages to check the actual content

2. `PizzaKitchenContractTest.testDeliverEndpointIsConformantToSpec()`

Ensure that the exposed API `PUT /deliver` conforms to the new `kitchen-openapi.yaml` spec.
Handy to ensure we didn't break the backward compatibility when applying changes / adding new features.

3. `PizzaKitchenContractTest.testCompleteFlowAndBusinessLogicIsConformantToSpecs()`

Validate the complete flow and both contracts (OpenAPI and AsyncAPI) using Microcks only. 
- Microcks invokes the `PUT /prepare` endpoint on one side and checks conformance
- During that time, it also listens to Kafka topic to check related messages are actually sent and that they're valid.