### PR TITLE
Add Microcks mocking / contract/interaction testing + update to latest Dapr and Spring Boot on pizza-store

### DIFF
--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -21,5 +21,10 @@
       <option name="name" value="JBoss Community repository" />
       <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
     </remote-repository>
+    <remote-repository>
+      <option name="id" value="ossrh" />
+      <option name="name" value="ossrh" />
+      <option name="url" value="https://oss.sonatype.org/content/repositories/snapshots" />
+    </remote-repository>
   </component>
 </project>

--- a/pizza-store/pom.xml
+++ b/pizza-store/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.3</version>
+		<version>3.3.7</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>io.diagrid.dapr</groupId>
@@ -29,17 +29,19 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
+
         <dependency>
-            <groupId>io.diagrid.dapr</groupId>
+            <groupId>io.dapr.spring</groupId>
             <artifactId>dapr-spring-boot-starter</artifactId>
-            <version>0.10.7</version>
+            <version>0.14.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-	  <groupId>com.github.wiremock</groupId>
-	  <artifactId>wiremock-testcontainers-java</artifactId>
-	  <version>1.0-alpha-13</version>
-	  <scope>test</scope>
-	</dependency>
+            <groupId>io.dapr.spring</groupId>
+            <artifactId>dapr-spring-boot-starter-test</artifactId>
+            <version>0.14.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
@@ -54,6 +56,23 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
             <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.github.microcks</groupId>
+            <artifactId>microcks-testcontainers</artifactId>
+            <version>0.3.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>kafka</artifactId>
+            <version>1.20.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 	</dependencies>
@@ -83,9 +102,15 @@
     </build>
 
     <repositories>
-		<repository>
-			<id>jitpack.io</id>
-			<url>https://jitpack.io</url>
-		</repository>
+      <repository>
+        <id>ossrh</id>
+        <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        <snapshots>
+          <enabled>true</enabled>
+        </snapshots>
+        <releases>
+          <enabled>false</enabled>
+        </releases>
+      </repository>
 	</repositories>
 </project>

--- a/pizza-store/src/test/java/io/diagrid/dapr/DaprTestContainersConfig.java
+++ b/pizza-store/src/test/java/io/diagrid/dapr/DaprTestContainersConfig.java
@@ -1,0 +1,90 @@
+package io.diagrid.dapr;
+
+import io.dapr.testcontainers.Component;
+import io.dapr.testcontainers.DaprContainer;
+import io.dapr.testcontainers.DaprLogLevel;
+import io.dapr.testcontainers.HttpEndpoint;
+import io.dapr.testcontainers.Subscription;
+import io.github.microcks.testcontainers.MicrocksContainersEnsemble;
+import io.github.microcks.testcontainers.connection.KafkaConnection;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Map;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class DaprTestContainersConfig {
+    private static Network network = Network.newNetwork();
+    private KafkaContainer kafkaContainer;
+    private MicrocksContainersEnsemble ensemble;
+    private DaprContainer daprContainer;
+
+    @Bean
+    @ServiceConnection
+    KafkaContainer kafkaContainer() {
+        kafkaContainer = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"))
+            .withNetwork(network)
+            .withNetworkAliases("kafka")
+            .withListener(() -> "kafka:19092");
+        return kafkaContainer;
+    }
+
+    @Bean
+    MicrocksContainersEnsemble microcksEnsemble(DynamicPropertyRegistry registry) {
+        ensemble = new MicrocksContainersEnsemble(network, "quay.io/microcks/microcks-uber:1.11.0-native")
+            .withAsyncFeature()
+            .withAccessToHost(true)
+            .withKafkaConnection(new KafkaConnection("kafka:19092"))
+            .withMainArtifacts(
+                  "store-openapi.yaml", "store-asyncapi.yaml",
+                  "third-parties/kitchen-openapi.yaml", "third-parties/delivery-openapi.yaml",
+                  "third-parties/kitchen-asyncapi.yaml", "third-parties/delivery-asyncapi.yaml")
+            .withAsyncDependsOn(kafkaContainer);
+
+        return ensemble;
+    }
+
+    @Bean
+    @ServiceConnection
+    DaprContainer daprContainer(DynamicPropertyRegistry registry, KafkaContainer kafkaContainer, MicrocksContainersEnsemble ensemble) {
+        daprContainer = new DaprContainer("daprio/daprd")
+              .withAppName("local-dapr-app")
+              .withAppPort(8080)
+              .withNetwork(network)
+              .withComponent(new Component("kvstore", "state.in-memory", "v1", Map.of()))
+              .withComponent(new Component("pubsub", "pubsub.kafka", "v1",
+                    Map.of(
+                          "brokers", "kafka:19092",
+                          "authType", "none"
+                    )))
+              .withSubscription(new Subscription(
+                    "pizza-store-subscription",
+                    "pubsub", "topic", "/events"))
+              .withSubscription(new Subscription(
+                    "pizza-kitchen-subscription", "pubsub",
+                    ensemble.getAsyncMinionContainer().getKafkaMockTopic("Pizza Kitchen Events", "1.0.0", "RECEIVE receivePreparationEvents"),
+                    "/events"))
+              .withSubscription(new Subscription(
+                    "pizza-delivery-subscription", "pubsub",
+                    ensemble.getAsyncMinionContainer().getKafkaMockTopic("Pizza Delivery Events", "1.0.0", "RECEIVE receiveDeliveryEvents"),
+                    "/events"))
+              .withHttpEndpoint(new HttpEndpoint("kitchen-service",
+                    "http://microcks:8080/rest/Pizza+Kitchen+API/1.0.0"))
+              .withHttpEndpoint(new HttpEndpoint("delivery-service",
+                    "http://microcks:8080/rest/Pizza+Delivery+API/1.0.0"))
+              .withAppChannelAddress("host.testcontainers.internal")
+              .withDaprLogLevel(DaprLogLevel.DEBUG)
+              .dependsOn(kafkaContainer);
+
+        org.testcontainers.Testcontainers.exposeHostPorts(8080);
+
+        registry.add("DAPR_HTTP_ENDPOINT", daprContainer::getHttpEndpoint);
+
+        return daprContainer;
+    }
+}

--- a/pizza-store/src/test/java/io/diagrid/dapr/PizzaStoreAppTest.java
+++ b/pizza-store/src/test/java/io/diagrid/dapr/PizzaStoreAppTest.java
@@ -3,34 +3,12 @@ package io.diagrid.dapr;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-import org.springframework.boot.testcontainers.context.ImportTestcontainers;
-import org.springframework.context.annotation.Bean;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.wiremock.integrations.testcontainers.WireMockContainer;
-
-import io.diagrid.dapr.profiles.DaprBasicProfile;
-
-
 @SpringBootApplication
 public class PizzaStoreAppTest {
+
     public static void main(String[] args) {
         SpringApplication.from(PizzaStore::main)
-                .with(AppTestConfiguration.class)
+                .with(DaprTestContainersConfig.class)
                 .run(args);
     }
-
-    @ImportTestcontainers(DaprBasicProfile.class)
-    static class AppTestConfiguration {
-
-        @Bean
-        WireMockContainer wireMockContainer(DynamicPropertyRegistry properties) {
-
-            var container = new WireMockContainer("wiremock/wiremock:3.1.0")
-                    .withMappingFromResource("kitchen", "kitchen-service-stubs.json");
-
-                    properties.add("DAPR_HTTP_ENDPOINT", container::getBaseUrl);
-            return container;
-        }
-    }
-
 }

--- a/pizza-store/src/test/java/io/diagrid/dapr/PizzaStoreContractTest.java
+++ b/pizza-store/src/test/java/io/diagrid/dapr/PizzaStoreContractTest.java
@@ -1,0 +1,48 @@
+package io.diagrid.dapr;
+
+import io.github.microcks.testcontainers.MicrocksContainersEnsemble;
+import io.github.microcks.testcontainers.model.TestRequest;
+import io.github.microcks.testcontainers.model.TestResult;
+import io.github.microcks.testcontainers.model.TestRunnerType;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(classes=PizzaStoreAppTest.class, webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@Import(DaprTestContainersConfig.class)
+class PizzaStoreContractTest {
+
+   @Autowired
+   MicrocksContainersEnsemble microcksEnsemble;
+
+   @Test
+   void testPlaceOrderEndpointIsConformantToSpec() throws Exception {
+      // Prepare a Microcks test.
+      TestRequest openAPITest = new TestRequest.Builder()
+            .serviceId("Pizza Store API:1.0.0")
+            .runnerType(TestRunnerType.OPEN_API_SCHEMA.name())
+            .testEndpoint("http://host.testcontainers.internal:8080")
+            .timeout(Duration.ofSeconds(2))
+            .build();
+
+      TestResult testResult = microcksEnsemble.getMicrocksContainer().testEndpoint(openAPITest);
+
+      // You may inspect complete response object with following:
+      //ObjectMapper mapper = new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
+      //System.out.println(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(testResult));
+
+      assertTrue(testResult.isSuccess());
+      // We tested 1 operation (POST /order).
+      assertEquals(1, testResult.getTestCaseResults().size());
+      // We tested with 2 samples (salaboy and lbroudoux).
+      assertEquals(2, testResult.getTestCaseResults().get(0).getTestStepResults().size());
+   }
+}

--- a/pizza-store/src/test/java/io/diagrid/dapr/PizzaStoreInteractionTest.java
+++ b/pizza-store/src/test/java/io/diagrid/dapr/PizzaStoreInteractionTest.java
@@ -1,0 +1,163 @@
+package io.diagrid.dapr;
+
+import io.github.microcks.testcontainers.MicrocksContainersEnsemble;
+import io.github.microcks.testcontainers.model.TestRequest;
+import io.github.microcks.testcontainers.model.TestResult;
+import io.github.microcks.testcontainers.model.TestRunnerType;
+import io.github.microcks.testcontainers.model.UnidirectionalEvent;
+
+import io.dapr.client.DaprClient;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.testcontainers.shaded.org.awaitility.core.ConditionTimeoutException;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+
+@SpringBootTest(classes=PizzaStoreAppTest.class, webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@Import(DaprTestContainersConfig.class)
+class PizzaStoreInteractionTest {
+
+   @Autowired
+   MicrocksContainersEnsemble microcksEnsemble;
+
+   @Autowired
+   PizzaStore pizzaStore;
+   @Autowired
+   DaprClient daprClient;
+
+   @Test
+   void testKitchenPrepareIsCalledAfterOrderIsPlaced() throws Exception {
+      long kitchenInvocations = microcksEnsemble.getMicrocksContainer()
+            .getServiceInvocationsCount("Pizza Kitchen API", "1.0.0");
+
+      // Prepare a Microcks test.
+      TestRequest openAPITest = new TestRequest.Builder()
+            .serviceId("Pizza Store API:1.0.0")
+            .runnerType(TestRunnerType.OPEN_API_SCHEMA.name())
+            .testEndpoint("http://host.testcontainers.internal:8080")
+            .timeout(Duration.ofSeconds(2))
+            .build();
+
+      TestResult testResult = microcksEnsemble.getMicrocksContainer().testEndpoint(openAPITest);
+
+      // You may inspect complete response object with following:
+      //ObjectMapper mapper = new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
+      //System.out.println(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(testResult));
+
+      assertTrue(testResult.isSuccess());
+      // We tested 1 operation (POST /order).
+      assertEquals(1, testResult.getTestCaseResults().size());
+      // We tested with 2 samples (salaboy and lbroudoux).
+      assertEquals(2, testResult.getTestCaseResults().get(0).getTestStepResults().size());
+
+      // Wait a second, ensuring the order threads are done.
+      TimeUnit.SECONDS.sleep(1L);
+
+      // Check that the kitchen service has been invoked twice (for salaboy and lbroudoux)
+      long newKitchenInvocations = microcksEnsemble.getMicrocksContainer()
+            .getServiceInvocationsCount("Pizza Kitchen API", "1.0.0");
+
+      //TimeUnit.SECONDS.sleep(30L);
+      assertTrue(newKitchenInvocations > kitchenInvocations);
+   }
+
+   @Test
+   void testDeliveryDeliverIsCalledWhenPreparationEventReceived() throws Exception {
+      // Empty the store and record number of mock invocations at the start.
+      daprClient.deleteState("kvstore", "orders").block();
+      long deliveryInvocations = microcksEnsemble.getMicrocksContainer()
+            .getServiceInvocationsCount("Pizza Delivery API", "1.0.0");
+
+      try {
+         await().atMost(4, TimeUnit.SECONDS)
+               .pollDelay(400, TimeUnit.MILLISECONDS)
+               .pollInterval(400, TimeUnit.MILLISECONDS)
+               .until(() -> {
+                  PizzaStore.Orders orders = pizzaStore.loadOrders();
+                  if (orders != null) {
+                     for (PizzaStore.Order order : orders.orders()) {
+                        if ("123-456-789".equals(order.id())) {
+                           long newDeliveryInvocations = microcksEnsemble.getMicrocksContainer()
+                                 .getServiceInvocationsCount("Pizza Delivery API", "1.0.0");
+
+                           assertTrue(newDeliveryInvocations > deliveryInvocations);
+                           return true;
+                        }
+                     }
+                  }
+                  return false;
+               });
+      } catch (ConditionTimeoutException timeoutException) {
+         fail("The expected Order was not received/processed in expected delay");
+      }
+   }
+
+   /*
+   // Following test cannot work at the moment as Microcks only supports raw WebSocket and not STOMP over WS.
+   @Test
+   void testEventIsPublishedAfterOrderIsPlaced() throws Exception {
+      // Prepare a Microcks test for event production.
+      TestRequest wsTest = new TestRequest.Builder()
+            .serviceId("Pizza Store Events:1.0.0")
+            .filteredOperations(List.of("RECEIVE receiveOrderEvents"))
+            .runnerType(TestRunnerType.ASYNC_API_SCHEMA.name())
+            .testEndpoint("ws://host.testcontainers.internal:8080/ws")
+            .timeout(Duration.ofSeconds(4))
+            .build();
+
+
+      // Prepare a Microcks test for event trigerring endpoint.
+      TestRequest openAPITest = new TestRequest.Builder()
+            .serviceId("Pizza Store API:1.0.0")
+            .runnerType(TestRunnerType.OPEN_API_SCHEMA.name())
+            .testEndpoint("http://host.testcontainers.internal:8080")
+            .timeout(Duration.ofSeconds(2))
+            .build();
+
+      try {
+         // Launch the Microcks test and wait a bit to be sure it actually connects to Kafka.
+         CompletableFuture<TestResult> testResultFuture = microcksEnsemble.getMicrocksContainer().testEndpointAsync(wsTest);
+         TimeUnit.MILLISECONDS.sleep(750L);
+
+         // Invoke the application to emit an order event.
+         TestResult testResult = microcksEnsemble.getMicrocksContainer().testEndpoint(openAPITest);
+
+         // You may inspect complete response object with following:
+         //ObjectMapper mapper = new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
+         //System.out.println(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(testResult));
+
+         // Check this first interaction is ok.
+         assertTrue(testResult.isSuccess());
+
+         // Get the Microcks test result.
+         TestResult wsResult = testResultFuture.get();
+
+         // You may inspect complete response object with following:
+         //System.out.println(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(kafkaResult));
+
+         // Check success and that we read 2 valid message on the topic.
+         // Because 2 orders are placed (per the OpenAPI samples) and 1 messages are sent for each order.
+         assertTrue(wsResult.isSuccess());
+         assertFalse(wsResult.getTestCaseResults().isEmpty());
+         assertEquals(2, wsResult.getTestCaseResults().get(0).getTestStepResults().size());
+
+         // Check the content of the emitted event, read from Kafka topic.
+         List<UnidirectionalEvent> events = microcksEnsemble.getMicrocksContainer()
+               .getEventMessagesForTestCase(wsResult, "RECEIVE receiveOrderEvents");
+
+         assertEquals(2, events.size());
+
+      } catch (Exception e) {
+         fail("No exception should be thrown when testing WebSocket publication", e);
+      }
+   }
+   */
+}

--- a/pizza-store/src/test/java/io/diagrid/dapr/PizzaStoreTest.java
+++ b/pizza-store/src/test/java/io/diagrid/dapr/PizzaStoreTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.testcontainers.junit.jupiter.Testcontainers;
 import io.diagrid.dapr.PizzaStore.Customer;
 import io.diagrid.dapr.PizzaStore.Order;
 import io.diagrid.dapr.PizzaStore.OrderItem;
@@ -18,8 +17,7 @@ import java.util.Arrays;
 
 
 @SpringBootTest(classes=PizzaStoreAppTest.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Testcontainers
-public class PizzaStoreTest {
+class PizzaStoreTest {
 
     @LocalServerPort
     private int port;
@@ -30,7 +28,7 @@ public class PizzaStoreTest {
     }
     
     @Test
-    public void testPlaceOrder() throws Exception {
+    void testPlaceOrder() throws Exception {
         
        with().body(new Order(new Customer("salaboy", "salaboy@mail.com"), 
                                 Arrays.asList(new OrderItem(PizzaType.pepperoni, 1))))
@@ -41,7 +39,7 @@ public class PizzaStoreTest {
         
         
 
-        
+
     }
 
 }

--- a/pizza-store/src/test/resources/store-asyncapi.yaml
+++ b/pizza-store/src/test/resources/store-asyncapi.yaml
@@ -1,0 +1,179 @@
+asyncapi: 3.0.0
+info:
+  title: Pizza Store Events
+  version: 1.0.0
+  description: This API allows to track the events related to pizza orders.
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+defaultContentType: application/json
+channels:
+  orderEvents:
+    address: events
+    messages:
+      orderEvents:
+        $ref: '#/components/messages/event'
+    bindings:
+      ws:
+        method: POST
+operations:
+  receiveOrderEvents:
+    action: receive
+    channel:
+      $ref: '#/channels/orderEvents'
+    messages:
+      - $ref: '#/channels/orderEvents/messages/orderEvent'
+components:
+  messages:
+    event:
+      payload:
+        $ref: '#/components/schemas/ReceivedEvent'
+        examples:
+          - name: Created
+            payload: |-
+              {
+                "specversion" : "1.0",
+                "type" : "com.dapr.event.sent",
+                "data": {
+                  "type": "order-in-preparation",
+                  "service": "kitchen",
+                  "message": "Your Order is in the kitchen.",
+                  "order": {
+                    "customer":
+                      {
+                        "name":"salaboy",
+                        "email":"salaboy@mail.com"
+                      },
+                    "items":[
+                      {
+                        "type":"pepperoni",
+                        "amount":1
+                      }
+                    ],
+                    "id":"2d62b770-0a20-4f4d-a32a-893f48e831d1",
+                    "orderDate":"2023-10-31T18:13:55.571+00:00",
+                    "status":"inpreparation"
+                  }
+                }
+              }
+          - name: Prepared
+            payload: |-
+              {
+                "specversion" : "1.0",
+                "type" : "com.dapr.event.sent",
+                "data": {
+                  "type": "order-on-its-way",
+                  "service": "delivery",
+                  "message": "Your Order is half mile away from your home.",
+                  "order": {
+                    "customer":
+                      {
+                        "name":"salaboy",
+                        "email":"salaboy@mail.com"
+                      },
+                      "items":[
+                        {
+                          "type":"pepperoni",
+                          "amount":1
+                        }
+                      ],
+                      "id":"2d62b770-0a20-4f4d-a32a-893f48e831d1",
+                      "orderDate":"2023-10-31T18:13:55.571+00:00",
+                      "status":"delivery"
+                    }
+                }
+              }
+          - name: Completed
+            payload: |-
+              {
+                "specversion" : "1.0",
+                "type" : "com.dapr.event.sent",
+                "data": {
+                  "type": "order-completed",
+                  "service": "store",
+                  "message": "Your Order has been delivered.",
+                  "order": {
+                    "customer":
+                      {
+                        "name":"salaboy",
+                        "email":"salaboy@mail.com"
+                      },
+                    "items":[
+                      {
+                        "type":"pepperoni",
+                        "amount":1
+                      }
+                    ],
+                    "id":"2d62b770-0a20-4f4d-a32a-893f48e831d1",
+                    "orderDate":"2023-10-31T18:13:55.571+00:00",
+                    "status":"completed"
+                  }
+                }
+              }
+  schemas:
+    Order:
+      type: object
+      properties:
+        id:
+          type: string
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrderItem'
+        orderDate:
+          type: string
+        status:
+          type: string
+          enum:
+            - created
+            - inpreparation
+            - delivery
+            - completed
+      required:
+        - id
+        - items
+        - orderDate
+      additionalProperties: true
+    OrderItem:
+      type: object
+      properties:
+        type:
+          type: string
+        amount:
+          type: integer
+      required:
+        - type
+        - amount
+    Event:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - order-placed
+            - order-in-preparation
+            - order-out-for-delivery
+            - order-on-its-way
+            - order-ready
+        order:
+          $ref: '#/components/schemas/Order'
+        service:
+          type: string
+          enum:
+            - store
+            - kitchen
+            - delivery
+        message:
+          type: string
+      required:
+        - type
+        - order
+        - service
+        - message
+    ReceivedEvent:
+      type: object
+      allOf:
+        - $ref: 'https://raw.githubusercontent.com/cloudevents/spec/v1.0.1/spec.json'
+      properties:
+        data:
+          $ref: '#/components/schemas/Event'

--- a/pizza-store/src/test/resources/store-openapi.yaml
+++ b/pizza-store/src/test/resources/store-openapi.yaml
@@ -1,0 +1,104 @@
+openapi: 3.0.2
+info:
+  title: Pizza Store API
+  version: 1.0.0
+  description: This API allows to place and track orders on pizzas
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+paths:
+  /order:
+    post:
+      operationId: placeOrder
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Order'
+            examples:
+              salaboy:
+                value: |-
+                  {
+                    "id": "abc-def-ghi",
+                    "customer": {
+                      "name": "salaboy",
+                      "email": "salaboy@mail.com"
+                    },
+                    "items": [
+                      {
+                      "type":"pepperoni",
+                      "amount": 1
+                      }
+                    ]
+                  }
+              lbroudoux:
+                value:
+                  id: 123-456-789
+                  customer:
+                    name: lbroudoux
+                    email: laurent.broudoux@gmail.com
+                  items:
+                    - type: vegetarian
+                      amount: 1
+      responses:
+        '200':
+          description: Order is placed started
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Order'
+              examples:
+                salaboy:
+                  value: |-
+                    {
+                      "id": "abc-def-ghi",
+                      "customer": {
+                        "name": "salaboy",
+                        "email": "salaboy@mail.com"
+                      },
+                      "items": [
+                        {
+                        "type":"pepperoni",
+                        "amount": 1
+                        }
+                      ],
+                      "orderDate": "2025-01-30T18:26:57.805+00:00"
+                    }
+                lbroudoux:
+                  value:
+                    id: 123-456-789
+                    customer:
+                      name: lbroudoux
+                      email: laurent.broudoux@gmail.com
+                    items:
+                      - type: vegetarian
+                        amount: 1
+                    orderDate: "2025-01-30T18:26:57.905+00:00"
+components:
+  schemas:
+    Order:
+      type: object
+      properties:
+        id:
+          type: string
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrderItem'
+        orderDate:
+          type: string
+      required:
+        - id
+        - items
+      additionalProperties: true
+    OrderItem:
+      type: object
+      properties:
+        type:
+          type: string
+        amount:
+          type: integer
+      required:
+        - type
+        - amount

--- a/pizza-store/src/test/resources/third-parties/delivery-asyncapi.yaml
+++ b/pizza-store/src/test/resources/third-parties/delivery-asyncapi.yaml
@@ -1,0 +1,122 @@
+asyncapi: 3.0.0
+info:
+  title: Pizza Delivery Events
+  version: 1.0.0
+  description: This API allows to track the delivery status of pizza orders.
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+defaultContentType: application/json
+channels:
+  deliveryEvents:
+    address: events
+    messages:
+      deliveryEvent:
+        $ref: '#/components/messages/event'
+operations:
+  receiveDeliveryEvents:
+    action: receive
+    channel:
+      $ref: '#/channels/deliveryEvents'
+    messages:
+      - $ref: '#/channels/deliveryEvents/messages/deliveryEvent'
+components:
+  messages:
+    event:
+      payload:
+        $ref: '#/components/schemas/ReceivedEvent'
+      examples:
+        - name: On its way
+          payload:
+            specversion: '1.0'
+            type: com.dapr.event.sent
+            source: local-dapr-app
+            id: 952d739f-5556-4772-8187-c39e18139a88
+            time: '2025-01-29T09:27:15Z'
+            datacontenttype: application/json
+            data:
+              type: order-on-its-way
+              order:
+                customer:
+                  name: lbroudoux
+                  email: laurent.broudoux@gmail.com
+                id: 123-456-789
+                items:
+                  - type: vegetarian
+                    amount: 1
+                orderDate: 1738142460556
+              message: The order is on its way to your address.
+        - name: Completed
+          payload:
+            specversion: '1.0'
+            type: com.dapr.event.sent
+            source: local-dapr-app
+            id: 952d739f-5556-4772-8187-c39e18139a89
+            time: '2025-01-29T09:29:25Z'
+            data:
+              type: order-completed
+              order:
+                customer:
+                  name: lbroudoux
+                  email: laurent.broudoux@gmail.com
+                id: 123-456-789
+                items:
+                  - type: vegetarian
+                    amount: 1
+                orderDate: 1738142460556
+              message: Your order has been delivered.
+  schemas:
+    Order:
+      type: object
+      properties:
+        id:
+          type: string
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrderItem'
+        orderDate:
+          type: number
+      required:
+        - id
+        - items
+        - orderDate
+      additionalProperties: true
+    OrderItem:
+      type: object
+      properties:
+        type:
+          type: string
+        amount:
+          type: integer
+      required:
+        - type
+        - amount
+    Event:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - order-on-its-way
+            - order-completed
+        order:
+          $ref: '#/components/schemas/Order'
+        service:
+          type: string
+          enum:
+            - delivery
+        message:
+          type: string
+      required:
+        - type
+        - order
+        - service
+        - message
+    ReceivedEvent:
+      type: object
+      allOf:
+        - $ref: 'https://raw.githubusercontent.com/cloudevents/spec/v1.0.1/spec.json'
+      properties:
+        data:
+          $ref: '#/components/schemas/Event'

--- a/pizza-store/src/test/resources/third-parties/delivery-openapi.yaml
+++ b/pizza-store/src/test/resources/third-parties/delivery-openapi.yaml
@@ -1,0 +1,79 @@
+openapi: 3.0.2
+info:
+  title: Pizza Delivery API
+  version: 1.0.0
+  description: This API allows to start the delivery of pizzas
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+paths:
+  /deliver:
+    put:
+      operationId: startDelivery
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Order'
+            examples:
+              salaboy:
+                value: |-
+                  {
+                    "id": "abc-def-ghi",
+                    "customer": {
+                      "name": "salaboy",
+                      "email": "salaboy@mail.com"
+                    },
+                    "items": [
+                      {
+                      "type":"pepperoni",
+                      "amount": 1
+                      }
+                    ],
+                    "orderDate": 1738142460555
+                  }
+              lbroudoux:
+                value:
+                  id: 123-456-789
+                  customer:
+                    name: lbroudoux
+                    email: laurent.broudoux@gmail.com
+                  items:
+                    - type: vegetarian
+                      amount: 1
+                  orderDate: 1738142460556
+      responses:
+        '200':
+          description: Delivery started
+          x-microcks-refs:
+            - salaboy
+            - lbroudoux
+components:
+  schemas:
+    Order:
+      type: object
+      properties:
+        id:
+          type: string
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrderItem'
+        orderDate:
+          type: number
+      required:
+        - id
+        - items
+        - orderDate
+      additionalProperties: true
+    OrderItem:
+      type: object
+      properties:
+        type:
+          type: string
+        amount:
+          type: integer
+      required:
+        - type
+        - amount

--- a/pizza-store/src/test/resources/third-parties/kitchen-asyncapi.yaml
+++ b/pizza-store/src/test/resources/third-parties/kitchen-asyncapi.yaml
@@ -1,0 +1,122 @@
+asyncapi: 3.0.0
+info:
+  title: Pizza Kitchen Events
+  version: 1.0.0
+  description: This API allows to track the preparation process of pizza orders.
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+defaultContentType: application/json
+channels:
+  preparationEvents:
+    address: events
+    messages:
+      preparationEvent:
+        $ref: '#/components/messages/event'
+operations:
+  receivePreparationEvents:
+    action: receive
+    channel:
+      $ref: '#/channels/preparationEvents'
+    messages:
+      - $ref: '#/channels/preparationEvents/messages/preparationEvent'
+components:
+  messages:
+    event:
+      payload:
+        $ref: '#/components/schemas/ReceivedEvent'
+      examples:
+        - name: In preparation
+          payload:
+            specversion: '1.0'
+            type: com.dapr.event.sent
+            source: local-dapr-app
+            id: 952d739f-5556-4772-8187-c39e18139a86
+            time: '2025-01-29T09:27:15Z'
+            datacontenttype: application/json
+            data:
+              type: order-in-preparation
+              order:
+                customer:
+                  name: lbroudoux
+                  email: laurent.broudoux@gmail.com
+                id: 123-456-789
+                items:
+                  - type: vegetarian
+                    amount: 1
+                orderDate: 1738142460556
+              message: The order is now in the kitchen.
+        - name: Ready
+          payload:
+            specversion: '1.0'
+            type: com.dapr.event.sent
+            source: local-dapr-app
+            id: 952d739f-5556-4772-8187-c39e18139a87
+            time: '2025-01-29T09:29:25Z'
+            data:
+              type: order-ready
+              order:
+                customer:
+                  name: lbroudoux
+                  email: laurent.broudoux@gmail.com
+                id: 123-456-789
+                items:
+                  - type: vegetarian
+                    amount: 1
+                orderDate: 1738142460556
+              message: Your pizza is ready and waiting to be delivered.
+  schemas:
+    Order:
+      type: object
+      properties:
+        id:
+          type: string
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrderItem'
+        orderDate:
+          type: number
+      required:
+        - id
+        - items
+        - orderDate
+      additionalProperties: true
+    OrderItem:
+      type: object
+      properties:
+        type:
+          type: string
+        amount:
+          type: integer
+      required:
+        - type
+        - amount
+    Event:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - order-in-preparation
+            - order-ready
+        order:
+          $ref: '#/components/schemas/Order'
+        service:
+          type: string
+          enum:
+            - kitchen
+        message:
+          type: string
+      required:
+        - type
+        - order
+        - service
+        - message
+    ReceivedEvent:
+      type: object
+      allOf:
+        - $ref: 'https://raw.githubusercontent.com/cloudevents/spec/v1.0.1/spec.json'
+      properties:
+        data:
+          $ref: '#/components/schemas/Event'

--- a/pizza-store/src/test/resources/third-parties/kitchen-openapi.yaml
+++ b/pizza-store/src/test/resources/third-parties/kitchen-openapi.yaml
@@ -1,0 +1,79 @@
+openapi: 3.0.2
+info:
+  title: Pizza Kitchen API
+  version: 1.0.0
+  description: This API allows to start the preparation of pizzas
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+paths:
+  /prepare:
+    put:
+      operationId: startPreparation
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Order'
+            examples:
+              salaboy:
+                value: |-
+                  {
+                    "id": "abc-def-ghi",
+                    "customer": {
+                      "name": "salaboy",
+                      "email": "salaboy@mail.com"
+                    },
+                    "items": [
+                      {
+                      "type":"pepperoni",
+                      "amount": 1
+                      }
+                    ],
+                    "orderDate": 1738142460555
+                  }
+              lbroudoux:
+                value:
+                  id: 123-456-789
+                  customer:
+                    name: lbroudoux
+                    email: laurent.broudoux@gmail.com
+                  items:
+                    - type: vegetarian
+                      amount: 1
+                  orderDate: 1738142460556
+      responses:
+        '200':
+          description: Preparation started
+          x-microcks-refs:
+            - salaboy
+            - lbroudoux
+components:
+  schemas:
+    Order:
+      type: object
+      properties:
+        id:
+          type: string
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrderItem'
+        orderDate:
+          type: number
+      required:
+        - id
+        - items
+        - orderDate
+      additionalProperties: true
+    OrderItem:
+      type: object
+      properties:
+        type:
+          type: string
+        amount:
+          type: integer
+      required:
+        - type
+        - amount


### PR DESCRIPTION
This PR is only for `pizza-store` module. It's similar to https://github.com/salaboy/pizza/pull/12

# Changes

* Bump to Spring Boot 3.3.7
* Bump to Dapr spring-boot-starter 0.14.0-SNAPSHOT (needed for `HTTPEndpoint` support)
* Add KafkaContainer bound to Dapr sidecar
* Add Microcks support for mocking, contract-testing and interaction-testing

## New Microcks contract tests

1. `PizzaStoreContractTest.testPlaceOrderEndpointIsConformantToSpec()`

Ensure that the exposed API `POST /order` conforms to the new `store-openapi.yaml` spec.
Handy to ensure we didn't break the backward compatibility when applying changes / adding new features.

2. `PizzaStoreInteractionTest.testKitchenPrepareIsCalledAfterOrderIsPlaced()`

Ensure that placing an order via the API endpoint actually invokes the `Kitchen` service (that is mocked by Microcks)

3. `PizzaStoreInteractionTest.testDeliveryDeliverIsCalledWhenPreparationEventReceived()`

Ensure that the application receives Kafka events coming from the Kitchen service through the Dapr Sidecar. Validates that on reception of such an event, the `Delivery` service (mocked by Microcks) is invoked.