### PR TITLE
Remove events from spring-boot:test-run experience

### DIFF
--- a/pizza-delivery/pom.xml
+++ b/pizza-delivery/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>io.github.microcks</groupId>
             <artifactId>microcks-testcontainers</artifactId>
-            <version>0.3.0</version>
+            <version>0.3.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pizza-kitchen/pom.xml
+++ b/pizza-kitchen/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>io.github.microcks</groupId>
       <artifactId>microcks-testcontainers</artifactId>
-      <version>0.3.0</version>
+      <version>0.3.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pizza-store/pom.xml
+++ b/pizza-store/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>io.github.microcks</groupId>
       <artifactId>microcks-testcontainers</artifactId>
-      <version>0.3.0</version>
+      <version>0.3.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

Asynchronous events generation can pollute the experience when using `spring-boot:test-run` as the UI starts receiving events even without any action 😉  This change was made to only add them if we are running in pure JUnit tests mode.

Basically, it adds event definintions to Microcks only when not running in `spring-boot:test-run` mode:

```java
boolean isSpringTestRunExecution =  Arrays.stream(Thread.currentThread().getStackTrace())
              .anyMatch(element -> element.getClassName().equals("com.salaboy.pizza.store.PizzaStoreAppTest"));
if (!isSpringTestRunExecution) {
       ensemble.withMainArtifacts("third-parties/kitchen-asyncapi.yaml", "third-parties/delivery-asyncapi.yaml");
}
```

In addition, I also added 2 minor changes:
- Bump `io.github.microcks:microcks-testcontainers` to `0.3.1` for cleaner retrieval of REST endpoints
- Restore `org.testcontainers.Testcontainers.exposeHostPorts(8080);` to the containers config before setting it at the test app level seems not to be enough (tests we failing for a connection issue both in IDE and on command line)

